### PR TITLE
Added basic paging (next/previous page)

### DIFF
--- a/Imouto.BooruParser/Api.cs
+++ b/Imouto.BooruParser/Api.cs
@@ -36,6 +36,8 @@ public interface IBooruApiLoader
     Task<Post?> GetPostByMd5Async(string md5);
 
     Task<SearchResult> SearchAsync(string tags);
+    Task<SearchResult> GetNextPageAsync(SearchResult results);
+    Task<SearchResult> GetPreviousPageAsync(SearchResult results);
 
     Task<SearchResult> GetPopularPostsAsync(PopularType type);
 
@@ -58,7 +60,7 @@ public interface IBooruApiAccessor
 /// <param name="Page">For danbooru: b{lowest-history-id-on-current-page}</param>
 public record SearchToken(string Page);
 
-public record SearchResult(IReadOnlyCollection<PostPreview> Results);
+public record SearchResult(IReadOnlyCollection<PostPreview> Results, string SearchTags, int PageNumber);
 
 public record HistorySearchResult<T>(
     IReadOnlyCollection<T> Results,


### PR DESCRIPTION
I've added a basic paging functionality to all the API loaders.
To fetch the next page, the user needs to call the IBooruApiLoader.GetNextPageAsync method, and pass in the result of the current page.
For this purpose, I've also extended the SearchResult record with the tag search that lead to its creation and the page number of said search result.